### PR TITLE
fix(types): constructor can be empty

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,7 @@ declare namespace ImageCompressor {
 }
 
 declare class ImageCompressor {
-  constructor(file: File|Blob, options?: ImageCompressor.Options);
+  constructor(file?: File|Blob, options?: ImageCompressor.Options);
   compress(file: File|Blob, options?: ImageCompressor.Options): Promise<Blob>;
 }
 


### PR DESCRIPTION
The following `compress` example shows a constructor without parameters:
https://github.com/xkeshi/image-compressor#compressfile-options

The typings incorrectly state that `file` is mandatory in the constructor