### PR TITLE
Fixes #42

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ export function getOrientation(arrayBuffer) {
     const length = dataView.byteLength;
     let offset = 2;
 
-    while (offset < length) {
+    while (offset < length - 1) {
       if (dataView.getUint8(offset) === 0xFF && dataView.getUint8(offset + 1) === 0xE1) {
         app1Start = offset;
         break;


### PR DESCRIPTION
Since we're calling `dataView.getUint8(offset + 1)`, we need to make sure that `offset + 1` is at most equal to `dataView.byteLength - 1`.

I assume this happens for malformed (for example stenography) JPEG file not ending with the EOI marker.