### PR TITLE
Add support for custom background

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ export default class ImageCompressor {
         }
 
         // Override the default fill color (#000, black)
-        context.fillStyle = defaultFillStyle;
+        context.fillStyle = options.fillStyle || defaultFillStyle;
         context.fillRect(0, 0, width, height);
         context.save();
         context.translate(width / 2, height / 2);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ declare namespace ImageCompressor {
     quality?: number;
     mimeType?: string;
     convertSize?: number;
+    fillStyle?: string;
     beforeDraw?(context: CanvasRenderingContext2D, canvas: HTMLCanvasElement): void;
     drew?(context: CanvasRenderingContext2D, canvas: HTMLCanvasElement): void;
     success?(file: Blob): void;


### PR DESCRIPTION
If you have an image in `PNG` and you want is to change the background color and convert to `JPEG`, you can not because the color `#000` is being applied by default. This change accepts the possibility of having a personalized background.