### PR TITLE
feat: add `retainExif` option to retain Exif

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,6 +154,15 @@
                 </div>
               </div>
               <div class="form-group row">
+                <label for="inputRetainExif" class="col-5 col-form-label">retainExif</label>
+                <div class="col-7">
+                  <select class="form-control" name="retainExif" id="inputRetainExif" v-model.number="options.retainExif">
+                    <option :value="false">false</option>
+                    <option :value="true">true</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group row">
                 <label for="inputMimeType" class="col-5 col-form-label">mimeType</label>
                 <div class="col-7">
                   <input type="text" name="mimeType" class="form-control" id="inputMimeType" placeholder="auto" v-model.number="options.mimeType">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -24,6 +24,7 @@ window.addEventListener('DOMContentLoaded', function () {
           height: undefined,
           resize: 'none',
           quality: 0.8,
+          retainExif: false,
           mimeType: '',
           convertTypes: 'image/png',
           convertSize: 5000000,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  '{src,test}/**/*.js|*.conf*.js': 'vue-cli-service lint',
+  '{src,test}/**/*.js|*.conf*.js': 'eslint --fix',
   '{src,docs}/**/*.{css,scss,html}': 'stylelint --fix',
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -68,6 +68,12 @@ export default {
   quality: 0.8,
 
   /**
+   * If set `true`, the compressed image will retain exif.
+   * @type {boolean}
+  */
+  retainExif: false,
+
+  /**
    * The mime type of the output image.
    * By default, the original mime type of the source image file will be used.
    * @type {string}

--- a/test/specs/Compressor.spec.js
+++ b/test/specs/Compressor.spec.js
@@ -1,3 +1,5 @@
+import { getEXIF, blobToBase64, base64ToArrayBuffer } from '../../src/utilities';
+
 describe('Compressor', () => {
   it('should be a class (function)', () => {
     expect(Compressor).to.be.a('function');
@@ -78,6 +80,24 @@ describe('Compressor', () => {
           expect(result).to.equal(image);
           done();
         },
+      });
+    });
+  });
+
+  it('should same between the original image`s exif and the compressed image`s exif', (done) => {
+    window.loadImageAsBlob('/base/docs/images/picture.jpg', (image) => {
+      blobToBase64(image, (oBase64) => {
+        const exif = getEXIF(base64ToArrayBuffer(oBase64));
+
+        new Compressor(image, {
+          retainExif: true,
+          success(result) {
+            blobToBase64(result, (cBase64) => {
+              expect(getEXIF(base64ToArrayBuffer(cBase64)).sort()).to.deep.equal(exif.sort());
+              done();
+            });
+          },
+        });
       });
     });
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ declare namespace Compressor {
     height?: number;
     resize?: 'contain' | 'cover' | 'none';
     quality?: number;
+    retainExif?: boolean;
     mimeType?: string;
     convertTypes?: string | string[];
     convertSize?: number;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

By default, the Exif information will be lost in the compressed image. If you want to keep the Exif information of the original image you can set the `retainExif` option to `true`
