### PR TITLE
fix: #168 restrict `retainExif` to only for jpeg images 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,8 @@ export default class Compressor {
     } else {
       const reader = new FileReader();
       const checkOrientation = options.checkOrientation && mimeType === 'image/jpeg';
+      const retainExif = options.retainExif && mimeType === 'image/jpeg';
+      console.log(retainExif)
 
       this.reader = reader;
       reader.onload = ({ target }) => {
@@ -98,13 +100,13 @@ export default class Compressor {
           } else {
             data.url = URL.createObjectURL(file);
           }
-        } else if (options.retainExif) {
+        } else if (retainExif) {
           data.url = URL.createObjectURL(file);
         } else {
           data.url = result;
         }
 
-        if (options.retainExif) {
+        if (retainExif) {
           this.exif = getExif(result);
         }
 
@@ -120,7 +122,7 @@ export default class Compressor {
         this.reader = null;
       };
 
-      if (checkOrientation || options.retainExif) {
+      if (checkOrientation || retainExif) {
         reader.readAsArrayBuffer(file);
       } else {
         reader.readAsDataURL(file);
@@ -298,7 +300,7 @@ export default class Compressor {
           result,
         });
 
-        if (options.retainExif && blob) {
+        if (options.retainExif && blob && this.exif && this.exif.length) {
           const next = (arrayBuffer) => done(toBlob(arrayBufferToDataURL(
             insertExif(arrayBuffer, this.exif),
             options.mimeType,

--- a/src/index.js
+++ b/src/index.js
@@ -70,22 +70,19 @@ export default class Compressor {
       options.retainExif = false;
     }
 
-    if (URL && !options.checkOrientation && !options.retainExif) {
+    if (URL && ((!options.checkOrientation && !options.retainExif) || mimeType !== 'image/jpeg')) {
       this.load({
         url: URL.createObjectURL(file),
       });
     } else {
       const reader = new FileReader();
-      const checkOrientation = options.checkOrientation && mimeType === 'image/jpeg';
-      const retainExif = options.retainExif && mimeType === 'image/jpeg';
-      console.log(retainExif)
 
       this.reader = reader;
       reader.onload = ({ target }) => {
         const { result } = target;
         const data = {};
 
-        if (checkOrientation) {
+        if (options.checkOrientation) {
           // Reset the orientation value to its default value 1
           // as some iOS browsers will render image with its orientation
           const orientation = resetAndGetOrientation(result);
@@ -100,13 +97,10 @@ export default class Compressor {
           } else {
             data.url = URL.createObjectURL(file);
           }
-        } else if (retainExif) {
-          data.url = URL.createObjectURL(file);
         } else {
-          data.url = result;
+          data.url = URL.createObjectURL(file);
         }
-
-        if (retainExif) {
+        if (options.retainExif) {
           this.exif = getExif(result);
         }
 
@@ -121,12 +115,7 @@ export default class Compressor {
       reader.onloadend = () => {
         this.reader = null;
       };
-
-      if (checkOrientation || retainExif) {
-        reader.readAsArrayBuffer(file);
-      } else {
-        reader.readAsDataURL(file);
-      }
+      reader.readAsArrayBuffer(file);
     }
   }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome (version 109.0.5414.87)
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
Currently if `retainExif` is enabled, loading a .png file will result in a "Failed to load the image" error. This PR will will ignore the `retainExif` option for png images.