### PR TITLE
chore: add Safari incompatibility with webp conversion in README browser support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ The quality of the output image. It must be a number between `0` and `1`. If thi
 
 The mime type of the output image. By default, the original mime type of the source image file will be used.
 
+> **Note:** Safari does not support `mimeType` conversion to `"image/webp"`. For more details, see the [browser compatibility of the `canvas.toBlob`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility).
+
 ### convertTypes
 
 - Type: `Array` or `string` (multiple types should be separated by commas)
@@ -343,7 +345,6 @@ If you have to use another compressor with the same namespace, just call the `Co
 - Chrome (latest)
 - Firefox (latest)
 - Safari (latest)
-  - **Note:** Safari does not support `mimeType` conversion to `webp`. For more details, see the [toBlob browser compatibility documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility).
 - Opera (latest)
 - Edge (latest)
 - Internet Explorer 10+

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ If you have to use another compressor with the same namespace, just call the `Co
 - Chrome (latest)
 - Firefox (latest)
 - Safari (latest)
+  - **Note:** Safari does not support `mimeType` conversion to `webp`. For more details, see the [toBlob browser compatibility documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility).
 - Opera (latest)
 - Edge (latest)
 - Internet Explorer 10+


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Other Information**

IMO, It’s important to document that Safari cannot convert to mimeType `webp`. This issue may be likely common nowadays, given the large number of iPhone users and the widespread use of `webp`. And, Since we know this limitation, it would be nice to highlight it.

If this place doesn’t seem like the best fit, we could also create a Troubleshooting section or similar

Thanks for this great library!